### PR TITLE
set indent_size in EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,7 @@
 root = true
 
 [*]
+indent_size = 4
 indent_style = space
 charset = utf-8
 trim_trailing_whitespace = true


### PR DESCRIPTION
Currently `indent_size` is undefined. This PR sets it to 4, to match the existing code style.