### PR TITLE
Add wasmJs target

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,12 @@ kotlin {
                 api(libs.annotations)
             }
         }
+        wasmJsMain {
+            dependencies {
+                // Required, because compileOnly dependencies are not supported on Kotlin/Wasm
+                api(libs.annotations)
+            }
+        }
         commonTest {
             dependencies {
                 implementation(kotlin("test"))

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/kotlin-multiplatform.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/kotlin-multiplatform.gradle.kts
@@ -13,6 +13,10 @@ kotlin {
         browser()
         nodejs()
     }
+    wasmJs {
+        browser()
+        nodejs()
+    }
 
     linuxX64()
     linuxArm64()

--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -11,6 +11,10 @@ kotlin {
         browser()
         nodejs()
     }
+    wasmJs {
+        browser()
+        nodejs()
+    }
 
     nativeTarget()
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,3 +1,3 @@
 [libraries]
 annotations = { group = "org.jetbrains", name = "annotations", version = "26.0.1" }
-assertk = { group = "com.willowtreeapps.assertk", name = "assertk", version = "0.26.1" }
+assertk = { group = "com.willowtreeapps.assertk", name = "assertk", version = "0.28.1" }


### PR DESCRIPTION
This adds the `wasmJs` target to parsus and the demo module.  
The assertk dependency had to be updated from 0.26.1 to 0.28.1 to gain support for `wasmJs`.